### PR TITLE
Update environmental impact vignette text

### DIFF
--- a/vignettes/environmental_impact.Rmd
+++ b/vignettes/environmental_impact.Rmd
@@ -48,7 +48,7 @@ See `?airpol_get` for the type of air pollutants that you can add to a European 
 
 ## Direct and multiplied effects
 
-The direct effects will show how many thousand tons of extra greenhouse gases will be produced with each millions of euros of extra output from Belgium's industries. We are adding with `rows_add()` the greenhouse gas vector in a conforming form to inter-industry matrix of Belgium. We will only print the top five emitters. 
+The direct effects will show how many thousand tons of extra greenhouse gases will be produced with each millions of euros of extra output from Belgium's industries. We are adding with `supplementary_add()`—which wraps `rows_add()`—the greenhouse gas vector in a conforming form to inter-industry matrix of Belgium. We will only print the top five emitters.
 
 ```{r ghgindicators}
 be_io <- BE %>%


### PR DESCRIPTION
## Summary
- update the direct-effects description to refer to `supplementary_add()` and note its relationship to `rows_add()`

## Testing
- `Rscript -e "rmarkdown::render('vignettes/environmental_impact.Rmd', output_dir = 'vignettes')"` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc32c0d088323a864328812f0bfaf