### PR TITLE
Ensure real estate columns via reusable helper

### DIFF
--- a/R/airpol_get.R
+++ b/R/airpol_get.R
@@ -150,11 +150,6 @@ airpol_get <- function(airpol = "GHG",
   direct_match <- country_ghg %>%
     inner_join(ghg, by = "nace_r2")
 
-  L68 <- tibble(
-    nace_r2 = c("CPA_L68A", "CPA_L68B"),
-    values = c(0, 0)
-  )
-
   group_match <- country_ghg %>%
     rename(nace = nace_r2) %>%
     mutate(nace_r2 = substr(.data$nace, 1, 5)) %>%
@@ -167,14 +162,14 @@ airpol_get <- function(airpol = "GHG",
     left_join(
       direct_match %>%
         left_join(group_match, by = c("airpol", "nace_r2", "unit", "geo", "time", "values")) %>%
-        select(nace_r2, values) %>%
-        full_join(L68, by = c("nace_r2", "values")),
+        select(nace_r2, values),
       by = "nace_r2"
     ) %>%
     pivot_wider(
       names_from = nace_r2,
       values_from = values
     ) %>%
+    ensure_l68_columns(c("CPA_L68A", "CPA_L68B")) %>%
     mutate(indicator = paste0(airpol, "_emission")) %>%
     relocate(indicator, .before = everything())
 

--- a/R/employment_get.R
+++ b/R/employment_get.R
@@ -235,13 +235,11 @@ employment_get <- function(geo,
 
     ## No employment for imputed rent column--------------------------------
 
-    imputed_rent <- data.frame(
-      real_estate_imputed_a = 0
-    )
     primary_employment_input <- primary_employment_input %>%
       dplyr::ungroup() %>%
       select(iotables_label, values) %>%
-      tidyr::spread(iotables_label, values) # use iotables_label in this case
+      tidyr::spread(iotables_label, values) %>%
+      ensure_l68_columns("real_estate_imputed_a") # use iotables_label in this case
   } else if (labelling == "prod_na") { ## this is the product x product labelling format
     prefix <- data.frame(
       prod_na = paste0("employment_", emp_sex)
@@ -250,13 +248,11 @@ employment_get <- function(geo,
     primary_employment_input <- employment %>%
       dplyr::filter(variable == "prod_na")
 
-    imputed_rent <- data.frame(
-      CPA_L68A = 0
-    )
     primary_employment_input <- primary_employment_input %>%
       dplyr::ungroup() %>%
       dplyr::select(code, values) %>%
-      tidyr::spread(code, values) # use code for standard Eurostat library
+      tidyr::spread(code, values) %>%
+      ensure_l68_columns("CPA_L68A") # use code for standard Eurostat library
   } else if (labelling == "induse") { # this is the industry x industry labelling format
     prefix <- data.frame(
       induse = paste0("employment_", emp_sex)
@@ -265,20 +261,17 @@ employment_get <- function(geo,
     primary_employment_input <- employment %>%
       dplyr::filter(variable == "induse")
 
-    imputed_rent <- data.frame(
-      L68A = 0
-    )
     primary_employment_input <- primary_employment_input %>%
       dplyr::ungroup() %>%
       dplyr::select(code, values) %>%
-      tidyr::spread(code, values) # use code for standard Eurostat library
+      tidyr::spread(code, values) %>%
+      ensure_l68_columns("L68A") # use code for standard Eurostat library
   } else {
     warning("No L68A was added.")
     return(primary_employment_input)
   }
 
   return_employment <- cbind(prefix, primary_employment_input)
-  return_employment <- cbind(return_employment, imputed_rent)
 
   return_employment
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,8 +1,42 @@
 #' @keywords internal
 fn_na_to_null <- function(x) ifelse(is.na(x), 0, x)
 
-#' @title Validate source parameter
+#' @title Ensure L68-related columns exist
 #'
+#' @description Internal helper that guarantees the requested real-estate
+#'   columns exist in a wide-format data frame. Missing columns are appended with
+#'   zeros, while existing non-zero values are preserved.
+#'
+#' @param data A wide `data.frame`.
+#' @param columns Character vector of column names that must be present.
+#'
+#' @return The input data frame with any missing columns added and filled with
+#'   zeros.
+#'
+#' @keywords internal
+ensure_l68_columns <- function(data, columns) {
+  assertthat::assert_that(
+    is.data.frame(data),
+    msg = "`data` must be a data.frame"
+  )
+
+  assertthat::assert_that(
+    is.character(columns),
+    length(columns) > 0,
+    msg = "`columns` must be a non-empty character vector"
+  )
+
+  missing_columns <- setdiff(columns, names(data))
+
+  for (column in missing_columns) {
+    data[[column]] <- 0
+  }
+
+  data
+}
+
+#' @title Validate source parameter
+#' 
 #' @description Internal function that checks whether the given `source`
 #'   argument matches one of the supported Eurostat or UK table identifiers.
 #'

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -47,3 +47,29 @@ test_that("validate_source() correctly validates sources", {
   # Valid source
   expect_silent(validate_source("naio_10_cp1700"))
 })
+
+test_that("ensure_l68_columns() adds missing columns only once", {
+  df <- data.frame(existing = 1)
+
+  result <- ensure_l68_columns(df, c("CPA_L68A", "CPA_L68B"))
+
+  expect_named(result, c("existing", "CPA_L68A", "CPA_L68B"))
+  expect_identical(result$CPA_L68A, 0)
+  expect_identical(result$CPA_L68B, 0)
+
+  second <- ensure_l68_columns(result, c("CPA_L68A", "CPA_L68B"))
+
+  expect_named(second, c("existing", "CPA_L68A", "CPA_L68B"))
+  expect_identical(second$CPA_L68A, 0)
+  expect_identical(second$CPA_L68B, 0)
+})
+
+test_that("ensure_l68_columns() keeps existing non-zero values", {
+  df <- data.frame(CPA_L68A = 5, another = 2)
+
+  result <- ensure_l68_columns(df, c("CPA_L68A", "CPA_L68B"))
+
+  expect_identical(result$CPA_L68A, 5)
+  expect_identical(result$CPA_L68B, 0)
+  expect_identical(result$another, 2)
+})


### PR DESCRIPTION
## Summary
- add an internal `ensure_l68_columns()` utility that appends missing L68 columns with zeros
- replace bespoke column padding in `airpol_get()` and `employment_get()` with the shared helper
- extend unit tests to confirm the helper adds columns only once and preserves existing values

## Testing
- Rscript -e "testthat::test_dir('tests/testthat', reporter = 'summary')" *(fails: Rscript not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0c710d31c83239d1a0528e0a43480